### PR TITLE
More robust scan cutting for sensors with unstable RPM

### DIFF
--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -265,6 +265,12 @@ bool VelodyneDriver::poll(void)
 
   // Since the velodyne delivers data at a very high rate, keep
   // reading and publishing scans as fast as possible.
+  uint16_t curr_packet_azm = 0;
+  uint16_t prev_packet_phased_azm = 0;
+  uint16_t curr_packet_phased_azm = 0;
+  uint16_t phased_azimuth_next = 0;
+  uint16_t azimuth_gap = 0;
+  uint16_t phase = (uint16_t)round(config_.scan_phase*100);
   bool use_next_packet = true;
   uint processed_packets = 0;
   while (use_next_packet)
@@ -280,26 +286,27 @@ bool VelodyneDriver::poll(void)
     }
     processed_packets++;
 
+    // uint8_t  curr_packet_rmode;
     curr_packet_azm  = scan->packets.back().data[2]; // lower word of azimuth block 0
     curr_packet_azm |= scan->packets.back().data[3] << 8; // higher word of azimuth block 0
-    curr_packet_rmode = scan->packets.back().data[1204];
-    curr_packet_sensor_model = scan->packets.back().data[1205];
+    // curr_packet_rmode = scan->packets.back().data[1204];
+    // curr_packet_sensor_model = scan->packets.back().data[1205];
 
     // For correct pointcloud assembly, always stop the scan after passing the
     // zero phase point. The pointcloud assembler will remedy this after unpacking
     // the packets, by buffering the overshot azimuths for the next cloud.
+    curr_packet_phased_azm = (36000 + curr_packet_azm - phase) % 36000;
     if (processed_packets > 1)
     {
-      uint16_t phase = (uint16_t)round(config_.scan_phase*100);
-      uint16_t azimuth_gap = (36000 + curr_packet_azm - prev_packet_azm) % 36000;
-      uint16_t phased_azimuth_next = ((36000 + curr_packet_azm - phase) % 36000) + azimuth_gap;
+      azimuth_gap = (36000 + curr_packet_phased_azm - prev_packet_phased_azm) % 36000;
+      phased_azimuth_next = curr_packet_phased_azm + azimuth_gap;
 
-      if (phased_azimuth_next >= 36000 || phased_azimuth_next <= azimuth_gap)
+      if (phased_azimuth_next > 36000 || prev_packet_phased_azm > curr_packet_phased_azm)
       {
         use_next_packet = false;
       }
     }
-    prev_packet_azm = curr_packet_azm;
+    prev_packet_phased_azm = curr_packet_phased_azm;
   }
 
   // average the time stamp from first package and last package
@@ -318,7 +325,7 @@ bool VelodyneDriver::poll(void)
   diag_topic_->tick(scan->header.stamp);
   diagnostics_.update();
 
-  if (dump_file != "")                  // have PCAP file?
+  if (dump_file != "" && processed_packets > 1)                  // have PCAP file?
   {
     double scan_packet_rate = (double)(processed_packets - 1)/(lastTimeStamp - firstTimeStamp).toSec();
     input_->setPacketRate(scan_packet_rate);

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -307,7 +307,6 @@ bool VelodyneDriver::poll(void)
       if (packet_last_azm_phased < packet_first_azm_phased || packet_first_azm_phased < prev_packet_first_azm_phased)
       {
         use_next_packet = false;
-        std::cerr << processed_packets << ", " << packet_first_azm << ", " << packet_last_azm << std::endl;
       }
     }
     prev_packet_first_azm_phased = packet_first_azm_phased;

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -265,11 +265,12 @@ bool VelodyneDriver::poll(void)
 
   // Since the velodyne delivers data at a very high rate, keep
   // reading and publishing scans as fast as possible.
-  uint16_t curr_packet_azm = 0;
-  uint16_t prev_packet_phased_azm = 0;
-  uint16_t curr_packet_phased_azm = 0;
-  uint16_t phased_azimuth_next = 0;
-  uint16_t azimuth_gap = 0;
+  uint16_t packet_first_azm = 0;
+  uint16_t packet_first_azm_phased = 0;
+  uint16_t packet_last_azm = 0;
+  uint16_t packet_last_azm_phased = 0;
+  uint16_t prev_packet_first_azm_phased = 0;
+
   uint16_t phase = (uint16_t)round(config_.scan_phase*100);
   bool use_next_packet = true;
   uint processed_packets = 0;
@@ -287,26 +288,29 @@ bool VelodyneDriver::poll(void)
     processed_packets++;
 
     // uint8_t  curr_packet_rmode;
-    curr_packet_azm  = scan->packets.back().data[2]; // lower word of azimuth block 0
-    curr_packet_azm |= scan->packets.back().data[3] << 8; // higher word of azimuth block 0
+    packet_first_azm  = scan->packets.back().data[2]; // lower word of azimuth block 0
+    packet_first_azm |= scan->packets.back().data[3] << 8; // higher word of azimuth block 0
+
+    packet_last_azm = scan->packets.back().data[1102];
+    packet_last_azm |= scan->packets.back().data[1103] << 8;
+
     // curr_packet_rmode = scan->packets.back().data[1204];
     // curr_packet_sensor_model = scan->packets.back().data[1205];
 
     // For correct pointcloud assembly, always stop the scan after passing the
     // zero phase point. The pointcloud assembler will remedy this after unpacking
     // the packets, by buffering the overshot azimuths for the next cloud.
-    curr_packet_phased_azm = (36000 + curr_packet_azm - phase) % 36000;
+    packet_first_azm_phased = (36000 + packet_first_azm - phase) % 36000;
+    packet_last_azm_phased = (36000 + packet_last_azm - phase) % 36000;
     if (processed_packets > 1)
     {
-      azimuth_gap = (36000 + curr_packet_phased_azm - prev_packet_phased_azm) % 36000;
-      phased_azimuth_next = curr_packet_phased_azm + azimuth_gap;
-
-      if (phased_azimuth_next > 36000 || prev_packet_phased_azm > curr_packet_phased_azm)
+      if (packet_last_azm_phased < packet_first_azm_phased || packet_first_azm_phased < prev_packet_first_azm_phased)
       {
         use_next_packet = false;
+        std::cerr << processed_packets << ", " << packet_first_azm << ", " << packet_last_azm << std::endl;
       }
     }
-    prev_packet_phased_azm = curr_packet_phased_azm;
+    prev_packet_first_azm_phased = packet_first_azm_phased;
   }
 
   // average the time stamp from first package and last package

--- a/velodyne_driver/src/driver/driver.h
+++ b/velodyne_driver/src/driver/driver.h
@@ -67,11 +67,9 @@ private:
   double diag_max_freq_;
   boost::shared_ptr<diagnostic_updater::TopicDiagnostic> diag_topic_;
 
-  uint16_t prev_packet_azm;
-  uint16_t curr_packet_azm;
-  uint8_t  curr_packet_rmode; //    [strongest return or farthest mode => Singular Retruns per firing]
+  // uint8_t  curr_packet_rmode; //    [strongest return or farthest mode => Singular Retruns per firing]
                               // or [Both  => Dual Retruns per fire]
-  uint8_t  curr_packet_sensor_model; // extract the sensor id from packet
+  // uint8_t  curr_packet_sensor_model; // extract the sensor id from packet
   std::string dump_file; // string to hold pcap file name
 };
 


### PR DESCRIPTION
More robust policy for determining at which packet to cut the velodyne scan message.
Should help to reduce double/half/missed scans for sensors where RPM fluctuates.

NOTE: only tested on PCAP data from 4941 and 1089.

Signed-off-by: davidw <david.wong@tier4.jp>