### PR TITLE
Remove unnecessary diagnostic update

### DIFF
--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -340,7 +340,6 @@ bool VelodyneDriverCore::poll(void)
   // notify diagnostics that a message has been published, updating
   // its status
   diag_topic_->tick(scan->header.stamp);
-  diagnostics_.force_update();
 
   if (dump_file != "" && processed_packets > 1)                  // have PCAP file?
   {


### PR DESCRIPTION
- In ROS2, `diagnostic_updater::Updater` calls `update()` using timer
https://github.com/ros/diagnostics/blob/foxy/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp#L486-L494

-  `force_update()` is not necessary.