### PR TITLE
Remove unnecessary argument

### DIFF
--- a/velodyne_pointcloud/src/conversions/interpolate.cc
+++ b/velodyne_pointcloud/src/conversions/interpolate.cc
@@ -29,7 +29,7 @@ Interpolate::Interpolate(const rclcpp::NodeOptions & options)
     this->create_publisher<sensor_msgs::msg::PointCloud2>("velodyne_points_interpolate_ex", rclcpp::SensorDataQoS());
 
   interpolate_callback_group_ = this->create_callback_group(
-    rclcpp::CallbackGroupType::MutuallyExclusive, true);
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   auto subscriber_option = rclcpp::SubscriptionOptions();
   subscriber_option.callback_group = interpolate_callback_group_;
   // subscribe


### PR DESCRIPTION
`create_callback_group` in `foxy` does not have the second argument. The default value of that argument in `rolling` is true, so it can be removed.
- foxy
https://github.com/ros2/rclcpp/blob/791c23afe5a4b23bfbacbb2c83eb6f0abe4aa490/rclcpp/include/rclcpp/node.hpp#L144
- rolling
https://github.com/ros2/rclcpp/blob/72443ff295fcae98d24ff90a37828c4c282d7449/rclcpp/include/rclcpp/node.hpp#L149

### Review
Build with `foxy`
`colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --symlink-install --packages-up-to velodyne_pointcloud`