### PR TITLE
Ignore -Wgnu-anonymous-struct and -Wnested-anon-types

### DIFF
--- a/velodyne_pointcloud/CMakeLists.txt
+++ b/velodyne_pointcloud/CMakeLists.txt
@@ -9,6 +9,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
+# Ignore PCL erros in Clang
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-gnu-anonymous-struct -Wno-nested-anon-types)
+endif()
+
 set(CMAKE_BUILD_TYPE "Release")
 
 find_package(ament_cmake_auto REQUIRED)


### PR DESCRIPTION
Clangビルドエラーの修正です。
変更量小＆暫定対策なのでupstreamには出さないでおきます。