### PR TITLE
Fix/Correct pcap rate adjustment

### DIFF
--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -114,7 +114,6 @@ namespace velodyne_driver
     void setPacketRate( const double packet_rate ); // necessary for automatic adjustment of rpm
   private:
     ros::Rate packet_rate_;
-    ros::Duration *pwait_time;
     std::string filename_;
     pcap_t *pcap_;
     bpf_program pcap_packet_filter_;

--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -44,6 +44,8 @@ namespace velodyne_driver
 {
   static uint16_t DATA_PORT_NUMBER = 2368;     // default data port
   static uint16_t POSITION_PORT_NUMBER = 8308; // default position port
+  static uint16_t TIMESTAMP_BYTE = 1200;       // timestamp byte position in data packet
+  static uint16_t BLOCK_LENGTH = 42;           // length of each data block in bytes
 
   /** @brief Velodyne input base class */
   class Input

--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -62,7 +62,6 @@ namespace velodyne_driver
      */
     virtual int getPacket(velodyne_msgs::VelodynePacket *pkt,
                           const double time_offset) = 0;
-    virtual void setPacketRate( const double packet_rate ) = 0; // necessary for automatic adjustment of rpm
 
   protected:
     ros::NodeHandle private_nh_;
@@ -83,7 +82,6 @@ namespace velodyne_driver
                           const double time_offset);
 
     void setDeviceIP( const std::string& ip );
-    void setPacketRate( const double packet_rate ) ; // necessary for automatic adjustment of rpm
 
   private:
     int sockfd_;
@@ -101,7 +99,6 @@ namespace velodyne_driver
   public:
     InputPCAP(ros::NodeHandle private_nh,
               uint16_t port = DATA_PORT_NUMBER,
-              double packet_rate = 0.0,
               std::string filename="",
               bool read_once=false,
               bool read_fast=false,
@@ -111,9 +108,9 @@ namespace velodyne_driver
     virtual int getPacket(velodyne_msgs::VelodynePacket *pkt,
                           const double time_offset);
     void setDeviceIP( const std::string& ip );
-    void setPacketRate( const double packet_rate ); // necessary for automatic adjustment of rpm
   private:
-    ros::Rate packet_rate_;
+    ros::Time last_packet_receive_time_;
+    ros::Time last_packet_stamp_;
     std::string filename_;
     pcap_t *pcap_;
     bpf_program pcap_packet_filter_;

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -239,8 +239,7 @@ VelodyneDriver::VelodyneDriver(ros::NodeHandle node,
   if (dump_file != "")                  // have PCAP file?
     {
       // read data from packet capture file
-      input_.reset(new velodyne_driver::InputPCAP(private_nh, udp_port,
-                                                  packet_rate, dump_file));
+      input_.reset(new velodyne_driver::InputPCAP(private_nh, udp_port, dump_file));
     }
   else
     {
@@ -328,11 +327,6 @@ bool VelodyneDriver::poll(void)
   diag_topic_->tick(scan->header.stamp);
   diagnostics_.update();
 
-  if (dump_file != "" && processed_packets > 1)                  // have PCAP file?
-  {
-    double scan_packet_rate = (double)(processed_packets - 1)/(lastTimeStamp - firstTimeStamp).toSec();
-    input_->setPacketRate(scan_packet_rate);
-  }
   return true;
 }
 

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -152,50 +152,41 @@ VelodyneDriver::VelodyneDriver(ros::NodeHandle node,
   ROS_DEBUG_STREAM("tf_prefix: " << tf_prefix);
   config_.frame_id = tf::resolve(tf_prefix, config_.frame_id);
 
-  // get model name, validate string, determine packet rate
+  // get model name, validate string
   private_nh.param("model", config_.model, std::string("64E"));
-  double packet_rate;                   // packet frequency (Hz)
   std::string model_full_name;
   if ((config_.model == "64E_S2") ||
-      (config_.model == "64E_S2.1"))    // generates 1333312 points per second
-    {                                   // 1 packet holds 384 points
-      packet_rate = 3472.17;            // 1333312 / 384
+      (config_.model == "64E_S2.1"))
+    {
       model_full_name = std::string("HDL-") + config_.model;
     }
   else if (config_.model == "64E")
     {
-      packet_rate = 2600.0;
       model_full_name = std::string("HDL-") + config_.model;
     }
-  else if (config_.model == "64E_S3") // generates 2222220 points per second (half for strongest and half for lastest)
-    {                                 // 1 packet holds 384 points
-      packet_rate = 5787.03;          // 2222220 / 384
+  else if (config_.model == "64E_S3")
+    {
       model_full_name = std::string("HDL-") + config_.model;
     }
   else if (config_.model == "32E")
     {
-      packet_rate = 1808.0;
       model_full_name = std::string("HDL-") + config_.model;
     }
     else if (config_.model == "32C")
     {
-      packet_rate = 1507.0;
       model_full_name = std::string("VLP-") + config_.model;
     }
   else if (config_.model == "VLP16")
     {
-      packet_rate = 754;              // 754 Packets/Second for Last or Strongest mode 1508 for dual (VLP-16 User Manual)
       model_full_name = "VLP-16";
     }
   else if (config_.model == "VLS128")
     {
-      packet_rate = 6030;             // Datasheet gives 6253.9 packets/second, but experimentally closer to this
       model_full_name = "VLS-128";
     }
   else
     {
       ROS_ERROR_STREAM("Unknown Velodyne LIDAR model: " << config_.model);
-      packet_rate = 2600.0;
     }
   std::string deviceName(std::string("Velodyne ") + model_full_name);
 

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -269,7 +269,6 @@ namespace velodyne_driver
     filter << "udp dst port " << port;
     pcap_compile(pcap_, &pcap_packet_filter_,
                  filter.str().c_str(), 1, PCAP_NETMASK_UNKNOWN);
-    pwait_time = NULL;
   }
 
   /** destructor */
@@ -278,14 +277,14 @@ namespace velodyne_driver
     pcap_close(pcap_);
   }
 
-  void InputPCAP::setPacketRate ( const double packet_rate)
+  void InputPCAP::setPacketRate(const double packet_rate)
   {
-    //packet_rate_(packet_rate);
-    if(pwait_time != NULL)
+    // Only update if changed
+    if (abs(1.0 / packet_rate_.expectedCycleTime().toSec() - packet_rate) > 0.1)
     {
-      delete pwait_time ;
+      packet_rate_ = ros::Rate(packet_rate);
     }
-    pwait_time = new ros::Duration(1.0/packet_rate);
+
   }
   /** @brief Get one velodyne packet. */
   int InputPCAP::getPacket(velodyne_msgs::VelodynePacket *pkt, const double time_offset)
@@ -310,10 +309,7 @@ namespace velodyne_driver
             // Keep the reader from blowing through the file.
             if (read_fast_ == false)
             {
-              if(pwait_time == NULL) // use initial estimated wait from configs
-                packet_rate_.sleep();
-              else
-                pwait_time->sleep();  // use auto rpm derived wait time
+              packet_rate_.sleep();
             }
 
             memcpy(&pkt->data[0], pkt_data+42, packet_size);

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -292,8 +292,8 @@ namespace velodyne_driver
               continue;
             }
 
-            memcpy(&pkt->data[0], pkt_data+42, packet_size);
-            pkt->stamp = rosTimeFromGpsTimestamp(&(pkt->data[1200])); // time_offset not considered here, as no synchronization required
+            memcpy(&pkt->data[0], pkt_data+BLOCK_LENGTH, packet_size);
+            pkt->stamp = rosTimeFromGpsTimestamp(&(pkt->data[TIMESTAMP_BYTE])); // time_offset not considered here, as no synchronization required
             empty_ = false;
 
             // Keep the reader from blowing through the file.
@@ -306,7 +306,7 @@ namespace velodyne_driver
                 ros::Time expected_end = last_packet_receive_time_ + expected_cycle_time;
                 ros::Time actual_end = ros::Time::now();
 
-                // D.etect backward jumps in time
+                // Detect backward jumps in time
                 if (actual_end < last_packet_receive_time_)
                 {
                   expected_end = actual_end + expected_cycle_time;


### PR DESCRIPTION
The previous VLS128 implementation attempted to adjust the pcap packet rate based on RPM (as RPM fluctuated) rather than using hard coded values.
This implementation was flawed, and is corrected by this PR.
Because it is unknown which return mode the sensor is in before the packets are read, either a new parameter is required, or the packet rate can be automatically adjusted as implemented in this PR. The hard coded values are for single return mode, but the result is that the first scan will be processed fast and subsequent scans will be assembled at the adjust (and correct) packet rate.