### PR TITLE
build: do not run all the linters with colcon tests

### DIFF
--- a/velodyne_msgs/CMakeLists.txt
+++ b/velodyne_msgs/CMakeLists.txt
@@ -24,9 +24,4 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
 ament_package()


### PR DESCRIPTION
This is making `colcon test` fail, but we can't control how the C and C++ generators produce code