### PR TITLE
Fix/Prevent checking last point of empty cloud in overflow buffer creation

### DIFF
--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -230,8 +230,11 @@ void Convert::processScan(const velodyne_msgs::msg::VelodyneScan::SharedPtr scan
       {
         _overflow_buffer.pc->points.push_back(scan_points_xyziradt.pc->points.back());
         scan_points_xyziradt.pc->points.pop_back();
-        current_azimuth = (int)scan_points_xyziradt.pc->points.back().azimuth;
-        phase_diff = (36000 + current_azimuth - phase) % 36000;
+        if (scan_points_xyziradt.pc->points.size() > 0)
+        {
+          current_azimuth = (int)scan_points_xyziradt.pc->points.back().azimuth;
+          phase_diff = (36000 + current_azimuth - phase) % 36000;
+        }
       }
       _overflow_buffer.pc->width = _overflow_buffer.pc->points.size();
     }


### PR DESCRIPTION
This PR resolves the issue where near-empty clouds (i.e. when the sensor is covered) can sometimes cause calling back() on an empty vector, resulting in undefined behavior and potential program crash.

Testing on pcaps and rosbags (veldyne_packets) that previously caused a program crash when the sensors were covered showed the error to be resolved.

See issue: https://tier4.atlassian.net/browse/T4PB-16873