### PR TITLE
perf(velodyne_convert_node): performance tuning

### DIFF
--- a/velodyne_pointcloud/CMakeLists.txt
+++ b/velodyne_pointcloud/CMakeLists.txt
@@ -54,6 +54,7 @@ ament_auto_add_library(cloud_nodelet SHARED
   src/conversions/convert.cc
   src/conversions/pointcloudXYZIR.cc
   src/conversions/pointcloudXYZIRADT.cc
+  src/conversions/output_builder.cc
   src/conversions/func.cc
 )
 target_link_libraries(cloud_nodelet velodyne_rawdata ${YAML_CPP_LIBRARIES} ${OpenCV_LIBS})

--- a/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
@@ -62,8 +62,6 @@ private:
   rclcpp::Subscription<velodyne_msgs::msg::VelodyneScan>::SharedPtr velodyne_scan_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr velodyne_points_pub_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr velodyne_points_ex_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr velodyne_points_invalid_near_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr velodyne_points_combined_ex_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_array_pub_;
 
   // tf2_ros::Buffer tf2_buffer_;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/output_builder.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/output_builder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cfloat>
 #include <memory>
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -25,8 +26,8 @@ class OutputBuilder : public velodyne_rawdata::DataContainerBase {
   bool output_xyzir_moved_ = false;
   bool xyzir_activated_ = false;
 
-  double min_range_;
-  double max_range_;
+  double min_range_ = 0;
+  double max_range_ = DBL_MAX;
 
   struct OffsetsXYZIRADT {
     uint32_t x_offset;
@@ -50,6 +51,9 @@ class OutputBuilder : public velodyne_rawdata::DataContainerBase {
 
   std::vector<pcl::PCLPointField> xyziradt_fields_;
   std::vector<pcl::PCLPointField> xyzir_fields_;
+
+  // Only used for PointXYZIR
+  double first_timestamp_ = 0;
 
   template <class PointT>
   void init_output_msg(sensor_msgs::msg::PointCloud2 & msg, size_t output_max_points_num,
@@ -79,10 +83,9 @@ public:
   // Needed for velodyne_convert_node logic
   uint16_t last_azimuth;
 
-  OutputBuilder(size_t output_max_points_num, const VelodyneScan & scan_msg);
+  OutputBuilder(size_t output_max_points_num, const VelodyneScan & scan_msg, bool activate_xyziradt, bool activate_xyzir);
 
-  void activate_xyziradt(double min_range, double max_range);
-  void activate_xyzir(double min_range, double max_range);
+  void set_extract_range(double min_range, double max_range);
 
   bool xyziradt_is_activated();
   bool xyzir_is_activated();

--- a/velodyne_pointcloud/include/velodyne_pointcloud/output_builder.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/output_builder.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <memory>
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <velodyne_pointcloud/datacontainerbase.h>
+#include <velodyne_pointcloud/pointcloudXYZIRADT.h>
+#include <velodyne_pointcloud/pointcloudXYZIR.h>
+#include <velodyne_msgs/msg/velodyne_scan.hpp>
+
+namespace velodyne_pointcloud {
+
+class OutputBuilder : public velodyne_rawdata::DataContainerBase {
+  using PointXYZIRADT = velodyne_pointcloud::PointXYZIRADT;
+  using PointXYZIR = velodyne_pointcloud::PointXYZIR;
+  using VelodyneScan = velodyne_msgs::msg::VelodyneScan;
+
+  std::unique_ptr<sensor_msgs::msg::PointCloud2> output_xyziradt_;
+  size_t output_xyziradt_data_size_ = 0;
+  bool output_xyziradt_moved_ = false;
+  bool xyziradt_activated_ = false;
+
+  std::unique_ptr<sensor_msgs::msg::PointCloud2> output_xyzir_;
+  size_t output_xyzir_data_size_ = 0;
+  bool output_xyzir_moved_ = false;
+  bool xyzir_activated_ = false;
+
+  double min_range_;
+  double max_range_;
+
+  struct OffsetsXYZIRADT {
+    uint32_t x_offset;
+    uint32_t y_offset;
+    uint32_t z_offset;
+    uint32_t intensity_offset;
+    uint32_t ring_offset;
+    uint32_t azimuth_offset;
+    uint32_t distance_offset;
+    uint32_t return_type_offset;
+    uint32_t time_stamp_offset;
+  } offsets_xyziradt_;
+
+  struct OffsetsXYZIR {
+    uint32_t x_offset;
+    uint32_t y_offset;
+    uint32_t z_offset;
+    uint32_t intensity_offset;
+    uint32_t ring_offset;
+  } offsets_xyzir_;
+
+  std::vector<pcl::PCLPointField> xyziradt_fields_;
+  std::vector<pcl::PCLPointField> xyzir_fields_;
+
+  template <class PointT>
+  void init_output_msg(sensor_msgs::msg::PointCloud2 & msg, size_t output_max_points_num,
+      const velodyne_msgs::msg::VelodyneScan & scan_msg) {
+    msg.data.resize(output_max_points_num * sizeof(PointT));
+
+    msg.header = scan_msg.header;
+    // To be updated when a first point is added
+    msg.header.stamp = scan_msg.packets[0].stamp;
+
+    msg.height = 1;
+    msg.width = 0;
+
+    if (std::is_same<PointT, PointXYZIRADT>::value) pcl_conversions::fromPCL(xyziradt_fields_, msg.fields);
+    if (std::is_same<PointT, PointXYZIR>::value) pcl_conversions::fromPCL(xyzir_fields_, msg.fields);
+
+    // https://github.com/PointCloudLibrary/pcl/blob/b551ee47b24e90cfb430ee4474f569e1411cd7bc/common/include/pcl/PCLPointCloud2.h#L25-L26
+    static_assert(BOOST_ENDIAN_BIG_BYTE || BOOST_ENDIAN_LITTLE_BYTE, "unable to determine system endianness");
+    msg.is_bigendian = BOOST_ENDIAN_BIG_BYTE;
+
+    msg.point_step = sizeof(PointT);
+    msg.row_step = sizeof(PointT) * msg.width;
+    msg.is_dense = true;
+  }
+
+public:
+  // Needed for velodyne_convert_node logic
+  uint16_t last_azimuth;
+
+  OutputBuilder(size_t output_max_points_num, const VelodyneScan & scan_msg);
+
+  void activate_xyziradt(double min_range, double max_range);
+  void activate_xyzir(double min_range, double max_range);
+
+  bool xyziradt_is_activated();
+  bool xyzir_is_activated();
+
+  std::unique_ptr<sensor_msgs::msg::PointCloud2> move_xyziradt_output();
+  std::unique_ptr<sensor_msgs::msg::PointCloud2> move_xyzir_output();
+
+  virtual void addPoint(
+    const float & x, const float & y, const float & z,
+    const uint8_t & return_type, const uint16_t & ring, const uint16_t & azimuth,
+    const float & distance, const float & intensity,
+    const double & time_stamp) override;
+};
+
+} // namespace velodyne_pointcloud
+

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -136,10 +136,6 @@ Convert::Convert(const rclcpp::NodeOptions & options)
   // advertise
   velodyne_points_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("velodyne_points", rclcpp::SensorDataQoS());
   velodyne_points_ex_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("velodyne_points_ex", rclcpp::SensorDataQoS());
-  velodyne_points_invalid_near_pub_ =
-    this->create_publisher<sensor_msgs::msg::PointCloud2>("velodyne_points_invalid_near", rclcpp::SensorDataQoS());
-  velodyne_points_combined_ex_pub_ =
-    this->create_publisher<sensor_msgs::msg::PointCloud2>("velodyne_points_combined_ex", rclcpp::SensorDataQoS());
   marker_array_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("velodyne_model_marker", 1);
   using std::placeholders::_1;
   set_param_res_ = this->add_on_set_parameters_callback(
@@ -203,9 +199,7 @@ void Convert::processScan(const velodyne_msgs::msg::VelodyneScan::SharedPtr scan
   velodyne_pointcloud::PointcloudXYZIRADT scan_points_xyziradt;
   if (
     velodyne_points_pub_->get_subscription_count() > 0 ||
-    velodyne_points_ex_pub_->get_subscription_count() > 0 ||
-    velodyne_points_invalid_near_pub_->get_subscription_count() > 0 ||
-    velodyne_points_combined_ex_pub_->get_subscription_count() > 0) {
+    velodyne_points_ex_pub_->get_subscription_count() > 0) {
     scan_points_xyziradt.pc->points.reserve(scanMsg->packets.size() * data_->scansPerPacket() + _overflow_buffer.pc->points.size());
 
     // Add the overflow buffer points
@@ -265,7 +259,7 @@ void Convert::processScan(const velodyne_msgs::msg::VelodyneScan::SharedPtr scan
       scan_points_xyziradt.pc->header.stamp =
         pcl_conversions::toPCL(scanMsg->packets[0].stamp);
     }
-    
+
     scan_points_xyziradt.pc->height = 1;
     scan_points_xyziradt.pc->width = scan_points_xyziradt.pc->points.size();
   }
@@ -274,8 +268,7 @@ void Convert::processScan(const velodyne_msgs::msg::VelodyneScan::SharedPtr scan
     new pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>);
   if (
     velodyne_points_pub_->get_subscription_count() > 0 ||
-    velodyne_points_ex_pub_->get_subscription_count() > 0 ||
-    velodyne_points_combined_ex_pub_->get_subscription_count() > 0) {
+    velodyne_points_ex_pub_->get_subscription_count() > 0) {
     valid_points_xyziradt =
       extractValidPoints(scan_points_xyziradt.pc, data_->getMinRange(), data_->getMaxRange());
     if (velodyne_points_pub_->get_subscription_count() > 0) {
@@ -289,44 +282,6 @@ void Convert::processScan(const velodyne_msgs::msg::VelodyneScan::SharedPtr scan
       pcl::toROSMsg(*valid_points_xyziradt, *ros_pc_msg_ptr);
       velodyne_points_ex_pub_->publish(std::move(ros_pc_msg_ptr));
     }
-  }
-
-  pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>::Ptr invalid_near_points_filtered_xyziradt(
-    new pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>);
-  if (
-    velodyne_points_invalid_near_pub_->get_subscription_count() > 0 ||
-    velodyne_points_combined_ex_pub_->get_subscription_count() > 0) {
-    const size_t num_lasers = data_->getNumLasers();
-    const auto sorted_invalid_points_xyziradt = sortZeroIndex(scan_points_xyziradt.pc, num_lasers);
-    invalid_near_points_filtered_xyziradt = extractInvalidNearPointsFiltered(
-      sorted_invalid_points_xyziradt, invalid_intensity_array_, num_lasers, num_points_threshold_);
-    if (velodyne_points_invalid_near_pub_->get_subscription_count() > 0) {
-      const auto invalid_near_points_filtered_xyzir =
-        convert(invalid_near_points_filtered_xyziradt);
-      auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
-      pcl::toROSMsg(*invalid_near_points_filtered_xyzir, *ros_pc_msg_ptr);
-      velodyne_points_invalid_near_pub_->publish(std::move(ros_pc_msg_ptr));
-    }
-  }
-
-  pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>::Ptr combined_points_xyziradt(
-    new pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>);
-  if (velodyne_points_combined_ex_pub_->get_subscription_count() > 0) {
-    combined_points_xyziradt->points.reserve(
-      valid_points_xyziradt->points.size() + invalid_near_points_filtered_xyziradt->points.size());
-    combined_points_xyziradt->points.insert(
-      std::end(combined_points_xyziradt->points), std::begin(valid_points_xyziradt->points),
-      std::end(valid_points_xyziradt->points));
-    combined_points_xyziradt->points.insert(
-      std::end(combined_points_xyziradt->points),
-      std::begin(invalid_near_points_filtered_xyziradt->points),
-      std::end(invalid_near_points_filtered_xyziradt->points));
-    combined_points_xyziradt->header = valid_points_xyziradt->header;
-    combined_points_xyziradt->height = 1;
-    combined_points_xyziradt->width = combined_points_xyziradt->points.size();
-    auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
-    pcl::toROSMsg(*combined_points_xyziradt, *ros_pc_msg_ptr);
-    velodyne_points_combined_ex_pub_->publish(std::move(ros_pc_msg_ptr));
   }
 
   if (marker_array_pub_->get_subscription_count() > 0) {

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -197,9 +197,7 @@ rcl_interfaces::msg::SetParametersResult Convert::paramCallback(const std::vecto
 /** @brief Callback for raw scan messages. */
 void Convert::processScan(const velodyne_msgs::msg::VelodyneScan::SharedPtr scanMsg)
 {
-
-
-  bool activate_xyziradt = velodyne_points_ex_pub_->get_subscription_count() == 0;
+  bool activate_xyziradt = velodyne_points_ex_pub_->get_subscription_count() > 0;
   bool activate_xyzir = velodyne_points_pub_->get_subscription_count() > 0;
 
   velodyne_pointcloud::OutputBuilder output_builder(
@@ -266,7 +264,6 @@ void Convert::processScan(const velodyne_msgs::msg::VelodyneScan::SharedPtr scan
   }
 
   if (output_builder.xyziradt_is_activated()) {
-
     velodyne_points_ex_pub_->publish(output_builder.move_xyziradt_output());
   }
 

--- a/velodyne_pointcloud/src/conversions/output_builder.cc
+++ b/velodyne_pointcloud/src/conversions/output_builder.cc
@@ -6,6 +6,12 @@
 namespace velodyne_pointcloud {
 
 OutputBuilder::OutputBuilder(size_t output_max_points_num, const VelodyneScan & scan_msg) {
+  pcl::for_each_type<typename pcl::traits::fieldList<PointXYZIRADT>::type>(
+      pcl::detail::FieldAdder<PointXYZIRADT>(xyziradt_fields_));
+
+  pcl::for_each_type<typename pcl::traits::fieldList<PointXYZIR>::type>(
+      pcl::detail::FieldAdder<PointXYZIR>(xyzir_fields_));
+
   output_xyziradt_ = std::make_unique<sensor_msgs::msg::PointCloud2>();
   init_output_msg<PointXYZIRADT>(*output_xyziradt_, output_max_points_num, scan_msg);
 
@@ -27,13 +33,6 @@ OutputBuilder::OutputBuilder(size_t output_max_points_num, const VelodyneScan & 
   offsets_xyzir_.z_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "z")].offset;
   offsets_xyzir_.intensity_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "intensity")].offset;
   offsets_xyzir_.ring_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "ring")].offset;
-
-  pcl::for_each_type<typename pcl::traits::fieldList<PointXYZIRADT>::type>(
-      pcl::detail::FieldAdder<PointXYZIRADT>(xyziradt_fields_));
-
-  pcl::for_each_type<typename pcl::traits::fieldList<PointXYZIR>::type>(
-      pcl::detail::FieldAdder<PointXYZIR>(xyzir_fields_));
-
 }
 
 void OutputBuilder::activate_xyziradt(double min_range, double max_range) {
@@ -97,15 +96,15 @@ void OutputBuilder::addPoint(
     }
 
     if (min_range_ <= distance && distance <= max_range_) {
-      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.x_offset]) = x;
-      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.y_offset]) = y;
-      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.z_offset]) = z;
-      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.intensity_offset]) = intensity;
-      *reinterpret_cast<uint16_t *>(msg.data[sz + offsets_xyziradt_.ring_offset]) = ring;
-      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.azimuth_offset]) = azimuth;
-      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.distance_offset]) = distance;
-      *reinterpret_cast<uint8_t *>(msg.data[sz + offsets_xyziradt_.return_type_offset]) = return_type;
-      *reinterpret_cast<double *>(msg.data[sz + offsets_xyziradt_.time_stamp_offset]) = time_stamp;
+      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.x_offset]) = x;
+      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.y_offset]) = y;
+      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.z_offset]) = z;
+      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.intensity_offset]) = intensity;
+      *reinterpret_cast<uint16_t *>(&msg.data[sz + offsets_xyziradt_.ring_offset]) = ring;
+      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.azimuth_offset]) = azimuth;
+      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.distance_offset]) = distance;
+      *reinterpret_cast<uint8_t *>(&msg.data[sz + offsets_xyziradt_.return_type_offset]) = return_type;
+      *reinterpret_cast<double *>(&msg.data[sz + offsets_xyziradt_.time_stamp_offset]) = time_stamp;
     }
 
     output_xyziradt_data_size_ += msg.point_step;
@@ -122,11 +121,11 @@ void OutputBuilder::addPoint(
     }
 
     if (min_range_ <= distance && distance <= max_range_) {
-      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.x_offset]) = x;
-      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.y_offset]) = y;
-      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.z_offset]) = z;
-      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.intensity_offset]) = intensity;
-      *reinterpret_cast<uint16_t *>(msg.data[sz + offsets_xyziradt_.ring_offset]) = ring;
+      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.x_offset]) = x;
+      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.y_offset]) = y;
+      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.z_offset]) = z;
+      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.intensity_offset]) = intensity;
+      *reinterpret_cast<uint16_t *>(&msg.data[sz + offsets_xyziradt_.ring_offset]) = ring;
     }
 
     output_xyzir_data_size_ += msg.point_step;

--- a/velodyne_pointcloud/src/conversions/output_builder.cc
+++ b/velodyne_pointcloud/src/conversions/output_builder.cc
@@ -1,0 +1,138 @@
+#include <boost/predef/other/endian.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <velodyne_pointcloud/output_builder.h>
+
+namespace velodyne_pointcloud {
+
+OutputBuilder::OutputBuilder(size_t output_max_points_num, const VelodyneScan & scan_msg) {
+  output_xyziradt_ = std::make_unique<sensor_msgs::msg::PointCloud2>();
+  init_output_msg<PointXYZIRADT>(*output_xyziradt_, output_max_points_num, scan_msg);
+
+  output_xyzir_ = std::make_unique<sensor_msgs::msg::PointCloud2>();
+  init_output_msg<PointXYZIR>(*output_xyzir_, output_max_points_num, scan_msg);
+
+  offsets_xyziradt_.x_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "x")].offset;
+  offsets_xyziradt_.y_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "y")].offset;
+  offsets_xyziradt_.z_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "z")].offset;
+  offsets_xyziradt_.intensity_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "intensity")].offset;
+  offsets_xyziradt_.ring_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "ring")].offset;
+  offsets_xyziradt_.azimuth_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "azimuth")].offset;
+  offsets_xyziradt_.distance_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "distance")].offset;
+  offsets_xyziradt_.return_type_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "return_type")].offset;
+  offsets_xyziradt_.time_stamp_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "time_stamp")].offset;
+
+  offsets_xyzir_.x_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "x")].offset;
+  offsets_xyzir_.y_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "y")].offset;
+  offsets_xyzir_.z_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "z")].offset;
+  offsets_xyzir_.intensity_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "intensity")].offset;
+  offsets_xyzir_.ring_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "ring")].offset;
+
+  pcl::for_each_type<typename pcl::traits::fieldList<PointXYZIRADT>::type>(
+      pcl::detail::FieldAdder<PointXYZIRADT>(xyziradt_fields_));
+
+  pcl::for_each_type<typename pcl::traits::fieldList<PointXYZIR>::type>(
+      pcl::detail::FieldAdder<PointXYZIR>(xyzir_fields_));
+
+}
+
+void OutputBuilder::activate_xyziradt(double min_range, double max_range) {
+  min_range_ = min_range;
+  max_range_ = max_range;
+  xyziradt_activated_ = true;
+}
+
+void OutputBuilder::activate_xyzir(double min_range, double max_range) {
+  min_range_ = min_range;
+  max_range_ = max_range;
+  xyzir_activated_ = true;
+}
+
+bool OutputBuilder::xyziradt_is_activated() {
+  return xyziradt_activated_;
+}
+
+bool OutputBuilder::xyzir_is_activated() {
+  return xyzir_activated_;
+}
+
+std::unique_ptr<sensor_msgs::msg::PointCloud2> OutputBuilder::move_xyziradt_output() {
+  if (!xyziradt_activated_ || output_xyziradt_moved_) {
+    return std::unique_ptr<sensor_msgs::msg::PointCloud2>(nullptr);
+  }
+
+  output_xyziradt_->data.resize(output_xyziradt_data_size_);
+
+  output_xyziradt_moved_ = true;
+  return std::move(output_xyziradt_);
+}
+
+std::unique_ptr<sensor_msgs::msg::PointCloud2> OutputBuilder::move_xyzir_output() {
+  if (!xyzir_activated_ || output_xyzir_moved_) {
+    return std::unique_ptr<sensor_msgs::msg::PointCloud2>(nullptr);
+  }
+
+  output_xyzir_->data.resize(output_xyzir_data_size_);
+
+  output_xyzir_moved_ = true;
+  return std::move(output_xyzir_);
+}
+
+void OutputBuilder::addPoint(
+    const float & x, const float & y, const float & z,
+    const uint8_t & return_type, const uint16_t & ring, const uint16_t & azimuth,
+    const float & distance, const float & intensity, const double & time_stamp) {
+  // Needed for velodyne_convert_node logic.
+  last_azimuth = azimuth;
+
+  auto stamp = rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>(time_stamp)).count());
+
+  if (xyziradt_activated_ && !output_xyziradt_moved_) {
+    auto &msg = *output_xyziradt_;
+    auto &sz = output_xyziradt_data_size_;
+
+    if (sz == 0) {
+      msg.header.stamp = stamp;
+    }
+
+    if (min_range_ <= distance && distance <= max_range_) {
+      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.x_offset]) = x;
+      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.y_offset]) = y;
+      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.z_offset]) = z;
+      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.intensity_offset]) = intensity;
+      *reinterpret_cast<uint16_t *>(msg.data[sz + offsets_xyziradt_.ring_offset]) = ring;
+      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.azimuth_offset]) = azimuth;
+      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.distance_offset]) = distance;
+      *reinterpret_cast<uint8_t *>(msg.data[sz + offsets_xyziradt_.return_type_offset]) = return_type;
+      *reinterpret_cast<double *>(msg.data[sz + offsets_xyziradt_.time_stamp_offset]) = time_stamp;
+    }
+
+    output_xyziradt_data_size_ += msg.point_step;
+    msg.width++;
+    msg.row_step += msg.point_step;
+  }
+
+  if (xyzir_activated_ && !output_xyziradt_moved_) {
+    auto &msg = *output_xyzir_;
+    auto &sz = output_xyzir_data_size_;
+
+    if (sz == 0) {
+      msg.header.stamp = stamp;
+    }
+
+    if (min_range_ <= distance && distance <= max_range_) {
+      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.x_offset]) = x;
+      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.y_offset]) = y;
+      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.z_offset]) = z;
+      *reinterpret_cast<float *>(msg.data[sz + offsets_xyziradt_.intensity_offset]) = intensity;
+      *reinterpret_cast<uint16_t *>(msg.data[sz + offsets_xyziradt_.ring_offset]) = ring;
+    }
+
+    output_xyzir_data_size_ += msg.point_step;
+    msg.width++;
+    msg.row_step += msg.point_step;
+  }
+}
+
+} // namespace velodyne_pointcloud

--- a/velodyne_pointcloud/src/conversions/output_builder.cc
+++ b/velodyne_pointcloud/src/conversions/output_builder.cc
@@ -5,7 +5,8 @@
 
 namespace velodyne_pointcloud {
 
-OutputBuilder::OutputBuilder(size_t output_max_points_num, const VelodyneScan & scan_msg) {
+OutputBuilder::OutputBuilder(size_t output_max_points_num, const VelodyneScan & scan_msg,
+    bool activate_xyziradt, bool activate_xyzir) : xyziradt_activated_(activate_xyziradt), xyzir_activated_(activate_xyzir) {
   pcl::for_each_type<typename pcl::traits::fieldList<PointXYZIRADT>::type>(
       pcl::detail::FieldAdder<PointXYZIRADT>(xyziradt_fields_));
 
@@ -13,38 +14,36 @@ OutputBuilder::OutputBuilder(size_t output_max_points_num, const VelodyneScan & 
       pcl::detail::FieldAdder<PointXYZIR>(xyzir_fields_));
 
   output_xyziradt_ = std::make_unique<sensor_msgs::msg::PointCloud2>();
-  init_output_msg<PointXYZIRADT>(*output_xyziradt_, output_max_points_num, scan_msg);
-
   output_xyzir_ = std::make_unique<sensor_msgs::msg::PointCloud2>();
-  init_output_msg<PointXYZIR>(*output_xyzir_, output_max_points_num, scan_msg);
 
-  offsets_xyziradt_.x_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "x")].offset;
-  offsets_xyziradt_.y_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "y")].offset;
-  offsets_xyziradt_.z_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "z")].offset;
-  offsets_xyziradt_.intensity_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "intensity")].offset;
-  offsets_xyziradt_.ring_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "ring")].offset;
-  offsets_xyziradt_.azimuth_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "azimuth")].offset;
-  offsets_xyziradt_.distance_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "distance")].offset;
-  offsets_xyziradt_.return_type_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "return_type")].offset;
-  offsets_xyziradt_.time_stamp_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "time_stamp")].offset;
+  if (xyziradt_activated_) {
+    init_output_msg<PointXYZIRADT>(*output_xyziradt_, output_max_points_num, scan_msg);
 
-  offsets_xyzir_.x_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "x")].offset;
-  offsets_xyzir_.y_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "y")].offset;
-  offsets_xyzir_.z_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "z")].offset;
-  offsets_xyzir_.intensity_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "intensity")].offset;
-  offsets_xyzir_.ring_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "ring")].offset;
+    offsets_xyziradt_.x_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "x")].offset;
+    offsets_xyziradt_.y_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "y")].offset;
+    offsets_xyziradt_.z_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "z")].offset;
+    offsets_xyziradt_.intensity_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "intensity")].offset;
+    offsets_xyziradt_.ring_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "ring")].offset;
+    offsets_xyziradt_.azimuth_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "azimuth")].offset;
+    offsets_xyziradt_.distance_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "distance")].offset;
+    offsets_xyziradt_.return_type_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "return_type")].offset;
+    offsets_xyziradt_.time_stamp_offset = output_xyziradt_->fields[pcl::getFieldIndex(*output_xyziradt_, "time_stamp")].offset;
+  }
+
+  if (xyzir_activated_) {
+    init_output_msg<PointXYZIR>(*output_xyzir_, output_max_points_num, scan_msg);
+
+    offsets_xyzir_.x_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "x")].offset;
+    offsets_xyzir_.y_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "y")].offset;
+    offsets_xyzir_.z_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "z")].offset;
+    offsets_xyzir_.intensity_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "intensity")].offset;
+    offsets_xyzir_.ring_offset = output_xyzir_->fields[pcl::getFieldIndex(*output_xyzir_, "ring")].offset;
+  }
 }
 
-void OutputBuilder::activate_xyziradt(double min_range, double max_range) {
+void OutputBuilder::set_extract_range(double min_range, double max_range) {
   min_range_ = min_range;
   max_range_ = max_range;
-  xyziradt_activated_ = true;
-}
-
-void OutputBuilder::activate_xyzir(double min_range, double max_range) {
-  min_range_ = min_range;
-  max_range_ = max_range;
-  xyzir_activated_ = true;
 }
 
 bool OutputBuilder::xyziradt_is_activated() {
@@ -62,6 +61,11 @@ std::unique_ptr<sensor_msgs::msg::PointCloud2> OutputBuilder::move_xyziradt_outp
 
   output_xyziradt_->data.resize(output_xyziradt_data_size_);
 
+  double time_stamp = *reinterpret_cast<double *>(&output_xyziradt_->data[offsets_xyziradt_.time_stamp_offset]);
+  auto stamp = rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>(time_stamp)).count());
+  output_xyziradt_->header.stamp = stamp;
+
   output_xyziradt_moved_ = true;
   return std::move(output_xyziradt_);
 }
@@ -72,6 +76,9 @@ std::unique_ptr<sensor_msgs::msg::PointCloud2> OutputBuilder::move_xyzir_output(
   }
 
   output_xyzir_->data.resize(output_xyzir_data_size_);
+  auto stamp = rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>(first_timestamp_)).count());
+  output_xyzir_->header.stamp = stamp;
 
   output_xyzir_moved_ = true;
   return std::move(output_xyzir_);
@@ -84,53 +91,63 @@ void OutputBuilder::addPoint(
   // Needed for velodyne_convert_node logic.
   last_azimuth = azimuth;
 
-  auto stamp = rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(
-        std::chrono::duration<double>(time_stamp)).count());
+  if (xyziradt_activated_ && !output_xyziradt_moved_ &&
+      min_range_ <= distance && distance <= max_range_) {
 
-  if (xyziradt_activated_ && !output_xyziradt_moved_) {
+    /* Slightly slower
     auto &msg = *output_xyziradt_;
     auto &sz = output_xyziradt_data_size_;
+    *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.x_offset]) = x;
+    *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.y_offset]) = y;
+    *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.z_offset]) = z;
+    *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.intensity_offset]) = intensity;
+    *reinterpret_cast<uint16_t *>(&msg.data[sz + offsets_xyziradt_.ring_offset]) = ring;
+    *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.azimuth_offset]) = azimuth;
+    *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.distance_offset]) = distance;
+    *reinterpret_cast<uint8_t *>(&msg.data[sz + offsets_xyziradt_.return_type_offset]) = return_type;
+    *reinterpret_cast<double *>(&msg.data[sz + offsets_xyziradt_.time_stamp_offset]) = time_stamp;
+    */
 
-    if (sz == 0) {
-      msg.header.stamp = stamp;
-    }
+    PointXYZIRADT *point = (PointXYZIRADT *) &output_xyziradt_->data[output_xyziradt_data_size_];
+    point->x = x;
+    point->y = y;
+    point->z = z;
+    point->intensity = intensity;
+    point->ring = ring;
+    point->azimuth = azimuth;
+    point->distance = distance;
+    point->return_type = return_type;
+    point->time_stamp = time_stamp;
 
-    if (min_range_ <= distance && distance <= max_range_) {
-      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.x_offset]) = x;
-      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.y_offset]) = y;
-      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.z_offset]) = z;
-      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.intensity_offset]) = intensity;
-      *reinterpret_cast<uint16_t *>(&msg.data[sz + offsets_xyziradt_.ring_offset]) = ring;
-      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.azimuth_offset]) = azimuth;
-      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.distance_offset]) = distance;
-      *reinterpret_cast<uint8_t *>(&msg.data[sz + offsets_xyziradt_.return_type_offset]) = return_type;
-      *reinterpret_cast<double *>(&msg.data[sz + offsets_xyziradt_.time_stamp_offset]) = time_stamp;
-    }
-
-    output_xyziradt_data_size_ += msg.point_step;
-    msg.width++;
-    msg.row_step += msg.point_step;
+    output_xyziradt_data_size_ += output_xyziradt_->point_step;
+    output_xyziradt_->width++;
+    output_xyziradt_->row_step += output_xyziradt_->point_step;
   }
 
-  if (xyzir_activated_ && !output_xyziradt_moved_) {
+  if (xyzir_activated_ && !output_xyzir_moved_ &&
+      min_range_ <= distance && distance <= max_range_) {
+    if (first_timestamp_ == 0) first_timestamp_ = time_stamp;
+
+    /* Slightly slower
     auto &msg = *output_xyzir_;
     auto &sz = output_xyzir_data_size_;
+    *reinterpret_cast<float *>(&msg.data[sz + offsets_xyzir_.x_offset]) = x;
+    *reinterpret_cast<float *>(&msg.data[sz + offsets_xyzir_.y_offset]) = y;
+    *reinterpret_cast<float *>(&msg.data[sz + offsets_xyzir_.z_offset]) = z;
+    *reinterpret_cast<float *>(&msg.data[sz + offsets_xyzir_.intensity_offset]) = intensity;
+    *reinterpret_cast<uint16_t *>(&msg.data[sz + offsets_xyzir_.ring_offset]) = ring;
+    */
 
-    if (sz == 0) {
-      msg.header.stamp = stamp;
-    }
+    PointXYZIR *point = (PointXYZIR *) &output_xyzir_->data[output_xyzir_data_size_];
+    point->x = x;
+    point->y = y;
+    point->z = z;
+    point->intensity = intensity;
+    point->ring = ring;
 
-    if (min_range_ <= distance && distance <= max_range_) {
-      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.x_offset]) = x;
-      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.y_offset]) = y;
-      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.z_offset]) = z;
-      *reinterpret_cast<float *>(&msg.data[sz + offsets_xyziradt_.intensity_offset]) = intensity;
-      *reinterpret_cast<uint16_t *>(&msg.data[sz + offsets_xyziradt_.ring_offset]) = ring;
-    }
-
-    output_xyzir_data_size_ += msg.point_step;
-    msg.width++;
-    msg.row_step += msg.point_step;
+    output_xyzir_data_size_ += output_xyzir_->point_step;
+    output_xyzir_->width++;
+    output_xyzir_->row_step += output_xyzir_->point_step;
   }
 }
 

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -198,6 +198,12 @@ namespace velodyne_rawdata
       return;
     }
 
+    /** special parsing for the VLS128 **/
+    if (calibration_.num_lasers == 128) {
+      unpack_vls128(pkt, data);
+      return;
+    }
+
     const raw_packet_t * raw = (const raw_packet_t *)&pkt.data[0];
 
     for (int i = 0; i < BLOCKS_PER_PACKET; i++) {
@@ -208,11 +214,6 @@ namespace velodyne_rawdata
       if (raw->blocks[i].header == LOWER_BANK) {
         // lower bank lasers are [32..63]
         bank_origin = 32;
-      }
-      /** special parsing for the VLS128 **/
-      else if (calibration_.num_lasers == 128) {
-        unpack_vls128(pkt, data);
-        return;
       }
 
       for (int j = 0, k = 0; j < SCANS_PER_BLOCK; j++, k += RAW_SCAN_SIZE) {


### PR DESCRIPTION
## Description
This PR makes `velodyne_convert_node` faster without changing the logical output. The tail latency of the `velodyne_convert_node`'s main callback gets about x2 faster with the introduction of the TLSF allocator (see [this Autoware Discussion](https://github.com/autowarefoundation/autoware/discussions/3274)) and this PR merge.

**when only `velodyne_points_ex_pub_` subscribed**

![velodyne_convert_node_performance_improvement_page-0001](https://user-images.githubusercontent.com/18254663/221383033-c2ad9099-15ec-48e9-8ce3-e8bf5a91bdb6.jpg)

**when only `velodyne_points_pub_` subscribed**

![velodyne_convert_node_performance_improvement_xyzir_page-0001](https://user-images.githubusercontent.com/18254663/221383040-5a83d446-7f07-499c-8ca6-c82edcba2dad.jpg)

Measurement Condition
- Ubuntu22.04 + ROS2 Humble + [Autoware Universe rosbag simulation](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)
- Core Isolated
- Core Frequency Fixed (2.6GHz)
- L3 Cache: 12MB

In order to minimize the copy cost, an in-place algorithm is applied as much as possible to create the output message.


## Related links
- [Introduction of a library for the replacement of heap allocation in Autoware (Autoware Discussion)](https://github.com/autowarefoundation/autoware/discussions/3274)
- [Background, Implementation Detail and Performance Analysis (TIER Ⅳ INTERNAL LINK)](https://tier4.atlassian.net/wiki/spaces/~5ed0b4584824b20c18371c06/pages/2579530588/awf.tutorial+velodyne+convert+node)

## Tests performed
Checked if `velodyne_convert_node` publishes the same logical output as before (using [Autoware Universe rosbag simulation](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)).
Tested for `velodyne_points_pub_` and `velodyne_points_ex_pub` outputs.

### Notice
- In [Autoware Universe rosbag simulation](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/), no point data is added to `_overflow_buffer`, the code paths for the buffer are not tested.
- I mentioned that the logical output is not changed, but precisely the `header.stamp` of the output message is changed in the form of a more accurate value. Before this PR, the timestamp data was divided by 1000 then multiplied by 1000. This PR fixes the problem of this approximation.
- Unused publishers are deleted