### PR TITLE
refactor autoware_auto_vehicle_msgs to autoware_vehicle_msgs

### DIFF
--- a/awf_velodyne_pointcloud/include/velodyne_pointcloud/func.h
+++ b/awf_velodyne_pointcloud/include/velodyne_pointcloud/func.h
@@ -19,7 +19,7 @@
 
 #include <pcl/point_cloud.h>
 
-#include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
+#include <autoware_vehicle_msgs/msg/velocity_report.hpp>
 
 #ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -49,7 +49,7 @@ pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>::Ptr extractInvalidNearPoint
 
 pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>::Ptr interpolate(
   const pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>::ConstPtr & input_pointcloud,
-  const std::deque<autoware_auto_vehicle_msgs::msg::VelocityReport> & velocity_report_queue,
+  const std::deque<autoware_vehicle_msgs::msg::VelocityReport> & velocity_report_queue,
   const tf2::Transform & tf2_base_link_to_sensor);
 
 pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>::Ptr sortRingNumber(

--- a/awf_velodyne_pointcloud/include/velodyne_pointcloud/interpolate.h
+++ b/awf_velodyne_pointcloud/include/velodyne_pointcloud/interpolate.h
@@ -27,7 +27,7 @@
 
 #include <tf2_ros/transform_listener.h>
 
-#include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
+#include <autoware_vehicle_msgs/msg/velocity_report.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -47,20 +47,20 @@ private:
 
   void processPoints(
     const sensor_msgs::msg::PointCloud2::SharedPtr points_xyziradt);
-  void processVelocityReport(const autoware_auto_vehicle_msgs::msg::VelocityReport::SharedPtr velocity_report_msg);
+  void processVelocityReport(const autoware_vehicle_msgs::msg::VelocityReport::SharedPtr velocity_report_msg);
   bool getTransform(
     const std::string & target_frame, const std::string & source_frame,
     tf2::Transform * tf2_transform_ptr);
 
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr velodyne_points_ex_sub_;
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>::SharedPtr velocity_report_sub_;
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::VelocityReport>::SharedPtr velocity_report_sub_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr velodyne_points_interpolate_pub_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr velodyne_points_interpolate_ex_pub_;
 
   tf2::BufferCore tf2_buffer_;
   tf2_ros::TransformListener tf2_listener_;
 
-  std::deque<autoware_auto_vehicle_msgs::msg::VelocityReport> velocity_report_queue_;
+  std::deque<autoware_vehicle_msgs::msg::VelocityReport> velocity_report_queue_;
 
   std::string base_link_frame_;
 };

--- a/awf_velodyne_pointcloud/package.xml
+++ b/awf_velodyne_pointcloud/package.xml
@@ -23,7 +23,7 @@
 
   <depend>angles</depend>
   <depend>diagnostic_updater</depend>
-  <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libpcl-all-dev</depend>
   <depend>message_filters</depend>

--- a/awf_velodyne_pointcloud/src/conversions/func.cc
+++ b/awf_velodyne_pointcloud/src/conversions/func.cc
@@ -161,7 +161,7 @@ pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>::Ptr extractInvalidNearPoint
 
 pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>::Ptr interpolate(
   const pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>::ConstPtr & input_pointcloud,
-  const std::deque<autoware_auto_vehicle_msgs::msg::VelocityReport> & velocity_report_queue,
+  const std::deque<autoware_vehicle_msgs::msg::VelocityReport> & velocity_report_queue,
   const tf2::Transform & tf2_base_link_to_sensor)
 {
   pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>::Ptr output_pointcloud(
@@ -182,7 +182,7 @@ pcl::PointCloud<velodyne_pointcloud::PointXYZIRADT>::Ptr interpolate(
   auto velocity_report_it = std::lower_bound(
     std::begin(velocity_report_queue), std::end(velocity_report_queue),
     rclcpp::Time(input_pointcloud->points.front().time_stamp, RCL_ROS_TIME),
-    [](const autoware_auto_vehicle_msgs::msg::VelocityReport & x, rclcpp::Time t) {
+    [](const autoware_vehicle_msgs::msg::VelocityReport & x, rclcpp::Time t) {
       return rclcpp::Time(x.header.stamp) < t;
     });
   velocity_report_it = velocity_report_it == std::end(velocity_report_queue) ? std::end(velocity_report_queue) - 1 : velocity_report_it;

--- a/awf_velodyne_pointcloud/src/conversions/interpolate.cc
+++ b/awf_velodyne_pointcloud/src/conversions/interpolate.cc
@@ -29,14 +29,14 @@ Interpolate::Interpolate(const rclcpp::NodeOptions & options)
     this->create_publisher<sensor_msgs::msg::PointCloud2>("velodyne_points_interpolate_ex", rclcpp::SensorDataQoS());
 
   // subscribe
-  velocity_report_sub_ = this->create_subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>(
+  velocity_report_sub_ = this->create_subscription<autoware_vehicle_msgs::msg::VelocityReport>(
     "/vehicle/status/velocity_status", 10,
     std::bind(&Interpolate::processVelocityReport, this, std::placeholders::_1));
   velodyne_points_ex_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
     "velodyne_points_ex", rclcpp::SensorDataQoS(), std::bind(&Interpolate::processPoints,this, std::placeholders::_1));
 }
 
-void Interpolate::processVelocityReport(const autoware_auto_vehicle_msgs::msg::VelocityReport::SharedPtr velocity_report_msg)
+void Interpolate::processVelocityReport(const autoware_vehicle_msgs::msg::VelocityReport::SharedPtr velocity_report_msg)
 {
   velocity_report_queue_.push_back(*velocity_report_msg);
 


### PR DESCRIPTION
the latest [autoware_msgs](https://github.com/autowarefoundation/autoware_msgs/tree/main/autoware_vehicle_msgs) has changed the `autoware_auto_vehicle_msgs` to `autoware_vehicle_msgs`.